### PR TITLE
URL Cleanup

### DIFF
--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -218,7 +218,7 @@ if [ -z "$shouldWriteConfig" ] && [ ! -f "$oldConfigFile" ] && [ ! -f "$newConfi
 	shouldWriteConfig=1
 fi
 
-# http://stackoverflow.com/a/2705678/433558
+# https://stackoverflow.com/a/2705678/433558
 sed_escape_lhs() {
 	echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
 }

--- a/3.7-rc/ubuntu/docker-entrypoint.sh
+++ b/3.7-rc/ubuntu/docker-entrypoint.sh
@@ -218,7 +218,7 @@ if [ -z "$shouldWriteConfig" ] && [ ! -f "$oldConfigFile" ] && [ ! -f "$newConfi
 	shouldWriteConfig=1
 fi
 
-# http://stackoverflow.com/a/2705678/433558
+# https://stackoverflow.com/a/2705678/433558
 sed_escape_lhs() {
 	echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
 }

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -218,7 +218,7 @@ if [ -z "$shouldWriteConfig" ] && [ ! -f "$oldConfigFile" ] && [ ! -f "$newConfi
 	shouldWriteConfig=1
 fi
 
-# http://stackoverflow.com/a/2705678/433558
+# https://stackoverflow.com/a/2705678/433558
 sed_escape_lhs() {
 	echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
 }

--- a/3.7/ubuntu/docker-entrypoint.sh
+++ b/3.7/ubuntu/docker-entrypoint.sh
@@ -218,7 +218,7 @@ if [ -z "$shouldWriteConfig" ] && [ ! -f "$oldConfigFile" ] && [ ! -f "$newConfi
 	shouldWriteConfig=1
 fi
 
-# http://stackoverflow.com/a/2705678/433558
+# https://stackoverflow.com/a/2705678/433558
 sed_escape_lhs() {
 	echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
 }

--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -218,7 +218,7 @@ if [ -z "$shouldWriteConfig" ] && [ ! -f "$oldConfigFile" ] && [ ! -f "$newConfi
 	shouldWriteConfig=1
 fi
 
-# http://stackoverflow.com/a/2705678/433558
+# https://stackoverflow.com/a/2705678/433558
 sed_escape_lhs() {
 	echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
 }

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -218,7 +218,7 @@ if [ -z "$shouldWriteConfig" ] && [ ! -f "$oldConfigFile" ] && [ ! -f "$newConfi
 	shouldWriteConfig=1
 fi
 
-# http://stackoverflow.com/a/2705678/433558
+# https://stackoverflow.com/a/2705678/433558
 sed_escape_lhs() {
 	echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -218,7 +218,7 @@ if [ -z "$shouldWriteConfig" ] && [ ! -f "$oldConfigFile" ] && [ ! -f "$newConfi
 	shouldWriteConfig=1
 fi
 
-# http://stackoverflow.com/a/2705678/433558
+# https://stackoverflow.com/a/2705678/433558
 sed_escape_lhs() {
 	echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://erlang.org/doc/applications.html (200) could not be migrated:  
   ([https](https://erlang.org/doc/applications.html) result ConnectTimeoutException).
* http://erlang.org/doc/installation_guide/INSTALL.html (200) could not be migrated:  
   ([https](https://erlang.org/doc/installation_guide/INSTALL.html) result ConnectTimeoutException).
* http://erlang.org/pipermail/erlang-questions/2019-January/097067.html (200) could not be migrated:  
   ([https](https://erlang.org/pipermail/erlang-questions/2019-January/097067.html) result ConnectTimeoutException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://stackoverflow.com/a/2705678/433558 migrated to:  
  https://stackoverflow.com/a/2705678/433558 ([https](https://stackoverflow.com/a/2705678/433558) result 302).